### PR TITLE
Update extension for Chrome Manifest V3

### DIFF
--- a/background.js
+++ b/background.js
@@ -26,7 +26,7 @@ function removeTab(id){
 
 var lastBrowserAction = null;
 
-chrome.browserAction.onClicked.addListener(function(tab){
+chrome.action.onClicked.addListener(function(tab){
   if(lastBrowserAction && Date.now() - lastBrowserAction < 10){
     // fix bug in Chrome Version 49.0.2623.87
     // that triggers browserAction.onClicked twice 
@@ -48,8 +48,8 @@ chrome.runtime.onSuspend.addListener(function() {
 });
 
 var dimensions = {
-  image: new Image(),
-  canvas: document.createElement('canvas'),
+  imageBitmap: null,
+  canvas: new OffscreenCanvas(1, 1),
   alive: true,
 
   activate: function(tab){
@@ -58,9 +58,9 @@ var dimensions = {
     this.onBrowserDisconnectClosure = this.onBrowserDisconnect.bind(this);
     this.receiveBrowserMessageClosure = this.receiveBrowserMessage.bind(this);
 
-    chrome.tabs.insertCSS(this.tab.id, { file: 'tooltip.css' });
-    chrome.tabs.executeScript(this.tab.id, { file: 'tooltip.chrome.js' });
-    chrome.browserAction.setIcon({ 
+    chrome.scripting.insertCSS({ target: { tabId: this.tab.id }, files: ['tooltip.css'] });
+    chrome.scripting.executeScript({ target: { tabId: this.tab.id }, files: ['tooltip.chrome.js'] });
+    chrome.action.setIcon({
       tabId: this.tab.id,
       path: {
         16: "images/icon16_active.png",
@@ -91,7 +91,7 @@ var dimensions = {
     this.port.onMessage.removeListener(this.receiveBrowserMessageClosure);
     this.port.onDisconnect.removeListener(this.onBrowserDisconnectClosure);
 
-    chrome.browserAction.setIcon({  
+    chrome.action.setIcon({
       tabId: this.tab.id,
       path: {
         16: "images/icon16.png",
@@ -101,7 +101,7 @@ var dimensions = {
       }
     });
 
-    window.removeTab(this.tab.id);
+    removeTab(this.tab.id);
   },
 
   onBrowserDisconnect: function(){
@@ -148,12 +148,14 @@ var dimensions = {
   },
 
   takeScreenshot: function(){
-    chrome.tabs.captureVisibleTab({ format: "png" }, this.parseScreenshot.bind(this));
+    chrome.tabs.captureVisibleTab({ format: "png" }).then(this.parseScreenshot.bind(this));
   },
 
-  parseScreenshot: function(dataUrl){
-    this.image.onload = this.loadImage.bind(this);
-    this.image.src = dataUrl;
+  parseScreenshot: async function(dataUrl){
+    const res = await fetch(dataUrl);
+    const blob = await res.blob();
+    this.imageBitmap = await createImageBitmap(blob);
+    this.loadImage();
   },
 
   //
@@ -169,9 +171,9 @@ var dimensions = {
     // adjust the canvas size to the image size
     this.canvas.width = this.tab.width;
     this.canvas.height = this.tab.height;
-    
+
     // draw the image to the canvas
-    this.ctx.drawImage(this.image, 0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.drawImage(this.imageBitmap, 0, 0, this.canvas.width, this.canvas.height);
     
     // read out the image data from the canvas
     var imgData = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height).data;

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,9 @@
 {
    "author": "Felix Niklas",
    "background": {
-      "persistent": false,
-      "scripts": [ "chrome.js" ]
+      "service_worker": "background.js"
    },
-   "browser_action": {
+   "action": {
       "default_icon": {
          "16": "images/icon16.png",
          "19": "images/icon19.png",
@@ -14,10 +13,10 @@
       "default_title": "Measure Dimensions"
    },
    "commands": {
-      "_execute_browser_action": {
-         "suggested_key": {
-            "default": "Alt+D"
-         }
+      "_execute_action": {
+        "suggested_key": {
+           "default": "Alt+D"
+        }
       }
    },
    "description": "A tool for designers to measure screen dimensions",
@@ -30,7 +29,7 @@
    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzchJpm92lToPQIrLWZWYaQXpAI4zt5mITrMeBg0ivJkxW252ImIrtLm5iVEoFN1EVG9m2OFyVOfrtMXfroy3PqjAmre6bntSgQRcYlTwvNoPvwrdpLn3ACirGthqp9sWGihDfWv2B1OJnp5kZc/KBPTC8nrj/6nTH3BaJ2s/4JEeTkTfWx5YkXEb69mPtLgRFZs4TaF381wvSdY/KBbZYvCrBGqj0uQ8qARx8KC2uY9pnWleSOpbEpAxU7KzXJ8c+bj64tVsliOenjbaRPhJBIxXQ/iZxGqsLsdOmLAkY0/CGRvS0Th/bD+oB46InmIxgFzm55gvcBt3yQfU30MlQQIDAQAB",
    "manifest_version": 3,
    "name": "Dimensions",
-   "permissions": [ "activeTab" ],
+   "permissions": [ "activeTab", "scripting" ],
    "update_url": "https://clients2.google.com/service/update2/crx",
    "version": "3"
 }


### PR DESCRIPTION
## Summary
- migrate Chrome extension to Manifest V3
- use service worker based background script
- adopt `chrome.action` and `chrome.scripting`
- update screenshot logic with `OffscreenCanvas`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68712ddd51a4832a8ea2bd567ba281f7